### PR TITLE
DEV-3140: fix tapclick

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## GH ionic-angular 3.9.4 Fork
+
+Fork created by Morley.
+
+In use by ActivatedYou-v1.24-PCI at the time of writing.
+
+- DEV-3140: Fixes an issue preventing clicking on any non-ionic element before
+clicking on an ionic-angular first after page load
+
 ## Ionic Framework
 
 The official npm package for [Ionic](https://ionicframework.com/), complete with pre-built ES5 bundles, TypeScript definitions, Sass files, CommonJS ES5 files, and more.

--- a/tap-click/tap-click.js
+++ b/tap-click/tap-click.js
@@ -19,6 +19,7 @@ var TapClick = (function () {
         this.gestureCtrl = gestureCtrl;
         this.disableClick = 0;
         this.events = new UIEventManager(plt);
+        this.dispatchClick = true;
         var activator = config.get('activator');
         if (activator === 'ripple') {
             this.activator = new RippleActivator(app, config, dom);


### PR DESCRIPTION
Fixes an issue preventing clicking on any non-ionic element before
clicking on an ionic-angular first after page load